### PR TITLE
add emberstake services

### DIFF
--- a/user-and-dev-tools/mainnet/interfaces.json
+++ b/user-and-dev-tools/mainnet/interfaces.json
@@ -46,6 +46,14 @@
     "Team or Contributor Name": "deNodes",
     "Discord UserName": "bombermine",
     "GitHub Account": "denodesxyz"
+  },
+  {
+    "Interface Name (Namadillo or Custom)": "Namadillo",
+    "Interface URL": "https://namadillo.emberstake.xyz",
+    "Notes": "",
+    "Team or Contributor Name": "EmberStake",
+    "Discord UserName": "4rash",
+    "GitHub Account": "EmberStake"
   }
 ]
 

--- a/user-and-dev-tools/mainnet/masp-indexers.json
+++ b/user-and-dev-tools/mainnet/masp-indexers.json
@@ -17,10 +17,16 @@
     "Discord UserName": "bombermine",
     "GitHub Account": "denodesxyz"
   },
-    {
+  {
     "Indexer API URL": "https://namada-masp-indexer.0xcryptovestor.com",
     "Team or Contributor Name": "Wavefive",
     "Discord UserName": "cryptovestor",
     "GitHub Account": "cryptovestor21"
+  },
+  {
+    "Indexer API URL": "https://namada-masp-idx.emberstake.xyz",
+    "Team or Contributor Name": "EmberStake",
+    "Discord UserName": "4rash",
+    "GitHub Account": "EmberStake"
   }
 ]

--- a/user-and-dev-tools/mainnet/namada-indexers.json
+++ b/user-and-dev-tools/mainnet/namada-indexers.json
@@ -40,5 +40,12 @@
     "Team or Contributor Name": "sproutstake",
     "Discord UserName": "oneplus",
     "GitHub Account": ""
+  },
+  {
+    "Which Indexer": "namada-indexer",
+    "Indexer API URL": "https://namada-idx.emberstake.xyz",
+    "Team or Contributor Name": "EmberStake",
+    "Discord UserName": "4rash",
+    "GitHub Account": "EmberStake"
   }
 ]

--- a/user-and-dev-tools/mainnet/rpc.json
+++ b/user-and-dev-tools/mainnet/rpc.json
@@ -142,5 +142,11 @@
     "Team or Contributor Name": "LiveRaveN",
     "Discord UserName": "liver23",
     "GitHub Account": "liver-23"
+  },
+  {
+    "RPC Address": "https://namada-rpc.emberstake.xyz",
+    "Team or Contributor Name": "EmberStake",
+    "Discord UserName": "4rash",
+    "GitHub Account": "EmberStake"
   }
 ]

--- a/user-and-dev-tools/mainnet/tooling-and-scripts.json
+++ b/user-and-dev-tools/mainnet/tooling-and-scripts.json
@@ -5,6 +5,7 @@
     "Team or Contributor Name": "EmberStake",
     "Discord UserName": "4rash",
     "GitHub Account": "https://github.com/0x4r45h",
+    "Tool URL": "https://github.com/EmberStake/namada-up",
     "Additional Note": "-"
   },
   {
@@ -13,6 +14,7 @@
     "Team or Contributor Name": "Mandragora",
     "Discord UserName": "danielmandragora",
     "GitHub Account": "https://github.com/McDaan",
+    "Tool URL": "-",
     "Additional Note": "-"
   },
   {
@@ -21,6 +23,7 @@
     "Team or Contributor Name": "Mandragora",
     "Discord UserName": "danielmandragora",
     "GitHub Account": "https://github.com/McDaan",
+    "Tool URL": "-",
     "Additional Note": "https://hackmd.io/@mandragora/namada-mainnet#Instructions-to-sync-a-node-via-state-sync-method"
   }
 ]


### PR DESCRIPTION
Add EmberStake services.    

Also, since there was no key for adding the actual URL of the tools, I added a new key, `"Tool URL"`, to the `user-and-dev-tools/mainnet/tooling-and-scripts.json` file. Feel free to rename the key if needed, but it is essential.