### PR TITLE
Add [new RPC endpoint] json

### DIFF
--- a/user-and-dev-tools/testnet/housefire/rpc.json
+++ b/user-and-dev-tools/testnet/housefire/rpc.json
@@ -52,5 +52,11 @@
     "Team or Contributor Name": "max-03",
     "Discord UserName": "power542",
     "GitHub Account": "maxpower-01"
+  },
+  {
+    "RPC Address": "https://housefire.rpc.papadritta.com",
+    "Team or Contributor Name": "papadritta",
+    "Discord UserName": "papadritta",
+    "GitHub Account": "papadritta"
   }
 ]


### PR DESCRIPTION
## This PR adds a fresh RPC endpoint for the Housefire Namada Testnet.

#### Changes Introduced:

- Added a new RPC address: `https://housefire.rpc.papadritta.com/`
- Contributor: `papadritta`
- GitHub: [papadritta](https://github.com/papadritta)
- Discord: `papadritta`