### PR TITLE
Update [IBC channel] json

### DIFF
--- a/user-and-dev-tools/testnet/housefire/ibc-relayers/housefire-osmo-test-5.json
+++ b/user-and-dev-tools/testnet/housefire/ibc-relayers/housefire-osmo-test-5.json
@@ -4,8 +4,8 @@
       {
         "chain_id": "housefire-alpaca.cc0d3e0c033be",
         "client_id": "07-tendermint-14",
-        "connection_id": "connection-6",
-        "channel_id": "channel-6",
+        "connection_id": "connection-12",
+        "channel_id": "channel-12",
         "port_id": "transfer",
         "supported_tokens": [
           {
@@ -17,9 +17,9 @@
       },
       {
         "chain_id": "osmo-test-5",
-        "client_id": "07-tendermint-4376",
-        "connection_id": "connection-3813",
-        "channel_id": "channel-10087",
+        "client_id": "07-tendermint-4392",
+        "connection_id": "connection-3834",
+        "channel_id": "channel-10103",
         "port_id": "transfer",
         "supported_tokens": [
           {


### PR DESCRIPTION
## Update IBC channel details: 
> for Housefire (housefire-alpaca.cc0d3e0c033be) <> Osmo (osmo-test-5)
#### Description:
1. Replaced expired `client 07-tendermint-4376` with a new valid client `07-tendermint-4392` on `osmo-test-5`.
2. Created a new connection `connection-3834` between `osmo-test-5` and `housefire-alpaca.cc0d3e0c033be`.
3. Established a new IBC channel:
- housefire-alpaca.cc0d3e0c033be: `channel-12 (connection connection-12)`
- osmo-test-5: `channel-10103 (connection connection-3834)`