### PR TITLE
Snapshot review

### DIFF
--- a/user-and-dev-tools/mainnet/snapshots.json
+++ b/user-and-dev-tools/mainnet/snapshots.json
@@ -1,6 +1,6 @@
 [
   {
-    "Snapshot Link": "https://namada.denodes.io/network-services/snapshots",
+    "Snapshot Link": "https://namada.denodes.io/snapshots",
     "Update Frequency": "12h",
     "Team or Contributor Name": "deNodes",
     "Discord UserName": "bombermine",
@@ -12,13 +12,6 @@
     "Team or Contributor Name": "Mandragora",
     "Discord UserName": "danielmandragora",
     "GitHub Account": "https:://github.com/McDaan"
-  },
-  {
-    "Snapshot Link": "https://hackmd.io/@mandragora/namada-mainnet#State-synced-snapshots",
-    "Update Frequency": "2-3h",
-    "Team or Contributor Name": "Mandragora",
-    "Discord UserName": "danielmandragora",
-    "GitHub Account": "https://github.com/McDaan"
   },
   {
     "Snapshot Link": "https://services.mellifera.network/Mainnet/Namada/Snapshot_and_data",
@@ -44,7 +37,7 @@
   {
     "Snapshot Link": "https://services.contributiondao.com/mainnet/namada/snapshots",
     "Update Frequency": "12h",
-    "Team or Contributor Name": "ContributionDAOJ",
+    "Team or Contributor Name": "ContributionDAO",
     "Discord UserName": "ntpcontribute",
     "GitHub Account": "addicola"
   },


### PR DESCRIPTION
- Mandragora listed twice
- ContributionDAO typo

Changes not made:
- ContributionDAO has no snapshots; RPC appears offline
- LOVD snapshot is ~4 days old
- StakeUp snapshot is ~4 days old

notified in Discord May 9: https://discord.com/channels/833618405537218590/1197233318001909900/1370545362464542740