### PR TITLE
update: IBC relayer config for `housefire-stride-1`

### DIFF
--- a/user-and-dev-tools/testnet/housefire/ibc-relayers/housefire-stride-1.json
+++ b/user-and-dev-tools/testnet/housefire/ibc-relayers/housefire-stride-1.json
@@ -3,9 +3,9 @@
     "chains": [
       {
         "chain_id": "housefire-alpaca.cc0d3e0c033be",
-        "client_id": "07-tendermint-16",
-        "connection_id": "connection-9",
-        "channel_id": "channel-8",
+        "client_id": "07-tendermint-22",
+        "connection_id": "connection-16",
+        "channel_id": "channel-14",
         "port_id": "transfer",
         "supported_tokens": [
           {
@@ -17,9 +17,9 @@
       },
       {
         "chain_id": "stride-1",
-        "client_id": "07-tendermint-163",
-        "connection_id": "connection-155",
-        "channel_id": "channel-306",
+        "client_id": "07-tendermint-164",
+        "connection_id": "connection-171",
+        "channel_id": "channel-323",
         "port_id": "transfer",
         "supported_tokens": [
           {


### PR DESCRIPTION
Updated client_id, connection_id, and channel_id values for both housefire-alpaca and stride-1 chains in the housefire-stride-1 IBC relayer configuration. This ensures the relayer uses the correct identifiers for current network connections.

Similar PR as: https://github.com/Luminara-Hub/namada-ecosystem/pull/235/files (`
Update housefire-stride-1.json info (Mandragora`) without the updated JSON files from GitHub Actions. 